### PR TITLE
Map the variable wght range to the standard OpenType wght range, make the Regular weight the default in the Variable exports.

### DIFF
--- a/src/Geist Mono/Geist-Mono.glyphs
+++ b/src/Geist Mono/Geist-Mono.glyphs
@@ -23,6 +23,10 @@ customParameters = (
 {
 name = "Use Typo Metrics";
 value = 1;
+},
+{
+name = "Variable Font Origin";
+value = m01;
 }
 );
 date = "2023-01-10 15:10:13 +0000";
@@ -524,6 +528,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
 }
 );
 iconName = Light;
@@ -600,6 +613,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400;
+}
+);
 }
 );
 id = m01;
@@ -674,6 +696,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 1000;
+}
+);
 }
 );
 iconName = Bold;
@@ -77524,6 +77555,17 @@ instances = (
 axesValues = (
 32
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 1;
 };
@@ -77533,6 +77575,17 @@ weightClass = 100;
 {
 axesValues = (
 42
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 200;
+}
+);
+}
 );
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.82143;
@@ -77545,6 +77598,17 @@ weightClass = 200;
 axesValues = (
 68
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 300;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.35714;
 m01 = 0.64286;
@@ -77556,6 +77620,17 @@ weightClass = 300;
 axesValues = (
 84
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.07143;
 m01 = 0.92857;
@@ -77565,6 +77640,17 @@ name = Regular;
 {
 axesValues = (
 106
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 500;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.11842;
@@ -77577,6 +77663,17 @@ weightClass = 500;
 axesValues = (
 126
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 600;
+}
+);
+}
+);
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.25;
 m01 = 0.75;
@@ -77587,6 +77684,17 @@ weightClass = 600;
 {
 axesValues = (
 146
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.38158;
@@ -77599,6 +77707,17 @@ weightClass = 700;
 axesValues = (
 176
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 800;
+}
+);
+}
+);
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.57895;
 m01 = 0.42105;
@@ -77609,6 +77728,17 @@ weightClass = 800;
 {
 axesValues = (
 208
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 900;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.78947;

--- a/src/Geist Sans/Geist-Sans.glyphs
+++ b/src/Geist Sans/Geist-Sans.glyphs
@@ -1,10 +1,6 @@
 {
 .appVersion = "3151";
 .formatVersion = 3;
-DisplayStrings = (
-"Bu/f_f.liga erasL?.",
-"ẞ"
-);
 axes = (
 {
 name = Weight;
@@ -15,6 +11,10 @@ customParameters = (
 {
 name = "Use Typo Metrics";
 value = 1;
+},
+{
+name = "Variable Font Origin";
+value = m01;
 }
 );
 date = "2023-01-10 15:10:13 +0000";
@@ -524,6 +524,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
 }
 );
 iconName = Light;
@@ -600,6 +609,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400;
+}
+);
 }
 );
 id = m01;
@@ -674,6 +692,15 @@ value = 920;
 {
 name = winDescent;
 value = 220;
+},
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 1000;
+}
+);
 }
 );
 iconName = Bold;
@@ -9466,7 +9493,7 @@ unicode = 82;
 },
 {
 glyphname = Racute;
-lastChange = "2023-08-30 19:14:38 +0000";
+lastChange = "2023-10-28 11:37:33 +0000";
 layers = (
 {
 layerId = m01;
@@ -9501,11 +9528,11 @@ shapes = (
 ref = R;
 },
 {
-pos = (258,180);
+pos = (260,180);
 ref = acutecomb;
 }
 );
-width = 628;
+width = 630;
 }
 );
 unicode = 340;
@@ -70986,6 +71013,17 @@ instances = (
 axesValues = (
 32
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 1;
 };
@@ -70995,6 +71033,17 @@ weightClass = 100;
 {
 axesValues = (
 42
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 200;
+}
+);
+}
 );
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.82143;
@@ -71007,6 +71056,17 @@ weightClass = 200;
 axesValues = (
 68
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 300;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.35714;
 m01 = 0.64286;
@@ -71018,6 +71078,17 @@ weightClass = 300;
 axesValues = (
 84
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400;
+}
+);
+}
+);
 instanceInterpolations = {
 "EE2FFE84-06F1-4AFB-BBEC-60D09A436D14" = 0.07143;
 m01 = 0.92857;
@@ -71027,6 +71098,17 @@ name = Regular;
 {
 axesValues = (
 106
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 500;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.11842;
@@ -71039,6 +71121,17 @@ weightClass = 500;
 axesValues = (
 126
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 600;
+}
+);
+}
+);
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.25;
 m01 = 0.75;
@@ -71049,6 +71142,17 @@ weightClass = 600;
 {
 axesValues = (
 146
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 700;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.38158;
@@ -71061,6 +71165,17 @@ weightClass = 700;
 axesValues = (
 176
 );
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 800;
+}
+);
+}
+);
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.57895;
 m01 = 0.42105;
@@ -71071,6 +71186,17 @@ weightClass = 800;
 {
 axesValues = (
 208
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 900;
+}
+);
+}
 );
 instanceInterpolations = {
 "37DC72B3-BCF2-46ED-AAD5-F0285A86700E" = 0.78947;


### PR DESCRIPTION
I've updated the Glyphs files so that the design `wght` range is mapped to the standard OpenType `wght` upon export. Additionally, the Regular weight is mapped to be the default state of the exported VFs.