### PR TITLE
Set Slashed Zero ('zero') feature tag

### DIFF
--- a/src/Geist Mono/Geist-Mono.glyphs
+++ b/src/Geist Mono/Geist-Mono.glyphs
@@ -65,6 +65,7 @@ feature ss06;
 feature ss07;
 feature ss08;
 feature ss09;
+feature zero;
 ";
 tag = aalt;
 },
@@ -485,6 +486,11 @@ value = "Alt numbers";
 }
 );
 tag = ss09;
+},
+{
+code = "sub zero by zero.ss09;
+";
+tag = zero;
 }
 );
 fontMaster = (

--- a/src/Geist Sans/Geist-Sans.glyphs
+++ b/src/Geist Sans/Geist-Sans.glyphs
@@ -60,6 +60,7 @@ feature ss06;
 feature ss07;
 feature ss08;
 feature ss09;
+feature zero;
 ";
 tag = aalt;
 },
@@ -485,6 +486,11 @@ value = "Alt numbers";
 }
 );
 tag = ss09;
+},
+{
+code = "sub zero by zero.ss09;
+";
+tag = zero;
 }
 );
 fontMaster = (


### PR DESCRIPTION
As brought up in #23, I noticed that a glyph for a slashed zero does already exist, but can only be enabled by setting the `ss09` feature tag.

This PR also substitutes the slashed zero glyph when setting the `zero` feature tag.