### PR TITLE
docs: update README.md with correct imports

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -17,7 +17,7 @@ npm install geist
 
 ### Using with Next.js
 
-`geist/font` exports `GeistSans` and `GeistMono`. Both are `NextFontWithVariable` instances. You can learn more by [reading the `next/font` docs](https://nextjs.org/docs/app/building-your-application/optimizing/fonts).
+`GeistSans` is exported from `geist/font/sans`, and `GeistMono` can be found in `geist/font/mono`. Both are `NextFontWithVariable` instances. You can learn more by [reading the `next/font` docs](https://nextjs.org/docs/app/building-your-application/optimizing/fonts).
 
 #### App Router
 
@@ -64,7 +64,8 @@ In `app/layout.js`:
 
 
 ```jsx
-import { GeistSans, GeistMono } from 'geist/font/sans'
+import { GeistSans } from 'geist/font/sans'
+import { GeistMono } from 'geist/font/mono'
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
It looks like importing `GeistSans` and `GeistMono` from `geist/font` were marked as deprecated as of `v1.1.0`. This just updates the README to reflect that. Also, `GeistMono` isn't part of `geist/font/sans`, so updating that in the README as well.

![Screenshot 2023-11-08 at 8 03 24 PM](https://github.com/vercel/geist-font/assets/21000200/feaf4885-e7e9-4589-bb75-ddc4b6ee7ac8)
