### PR TITLE
Fix inconsistencies in font weight on Safari

### DIFF
--- a/packages/next/dist/mono.js
+++ b/packages/next/dist/mono.js
@@ -15,4 +15,5 @@ export const GeistMono = localFont({
     "Courier New",
     "monospace",
   ],
+  weight: "100 900",
 });

--- a/packages/next/dist/sans.js
+++ b/packages/next/dist/sans.js
@@ -3,4 +3,5 @@ import localFont from "next/font/local";
 export const GeistSans = localFont({
   src: "./fonts/geist-sans/Geist-Variable.woff2",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geist",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.",
   "main": "./dist/font.js",
   "module": "./dist/font.js",


### PR DESCRIPTION
Prevents Safari from interpolating the font weights. Safari shouldn't need to interpolate because the variable font has the styles for it.