### PR TITLE
feat(next): loosen peer deps to allow `next@canary`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -53,6 +53,6 @@
   },
   "license": "SIL OPEN FONT LICENSE",
   "peerDependencies": {
-    "next": "^13.2 || ^14"
+    "next": ">=13.2.0 <15"
   }
 }

--- a/packages/next/pnpm-lock.yaml
+++ b/packages/next/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   next:
-    specifier: ^13.2 || ^14
+    specifier: '>=13.2.0 <15'
     version: 14.0.1(react-dom@18.2.0)(react@18.2.0)
 
 packages:


### PR DESCRIPTION
fixes https://github.com/vercel/geist-font/issues/76