### PR TITLE
fix(next): accept `next@canary` versions as peer deps

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -53,6 +53,6 @@
   },
   "license": "SIL OPEN FONT LICENSE",
   "peerDependencies": {
-    "next": ">=13.2.0 <15"
+    "next": ">=13.2.0 <15.0.0-0"
   }
 }

--- a/packages/next/pnpm-lock.yaml
+++ b/packages/next/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   next:
-    specifier: '>=13.2.0 <15'
+    specifier: '>=13.2.0 <15.0.0-0'
     version: 14.0.1(react-dom@18.2.0)(react@18.2.0)
 
 packages:


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/geist-font/pull/86, which does not work the way it is intended.