### PR TITLE
fix: exports configuration

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.0",
   "description": "Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.",
   "main": "./dist/font.js",
+  "type": "module",
   "module": "./dist/font.js",
-  "typings": "font.d.ts",
-  "types": "font.d.ts",
+  "types": "./font.d.ts",
   "scripts": {
     "prepare": "cp ../../LICENSE.TXT ."
   },
@@ -26,29 +26,24 @@
   ],
   "exports": {
     "./font": {
-      "import": "./dist/font.js",
-      "require": "./dist/font.js",
-      "default": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/font.js"
     },
     "./font/mono": {
-      "import": "./dist/mono.js",
-      "require": "./dist/mono.js",
-      "default": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/mono.js"
     },
     "./font/mono-non-variable": {
-      "import": "./dist/mono-non-variable.js",
-      "require": "./dist/mono-non-variable.js",
-      "default": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/mono-non-variable.js"
     },
     "./font/sans": {
-      "import": "./dist/sans.js",
-      "require": "./dist/sans.js",
-      "default": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/sans.js"
     },
     "./font/sans-non-variable": {
-      "import": "./dist/sans-non-variable.js",
-      "require": "./dist/sans-non-variable.js",
-      "default": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/sans-non-variable.js"
     }
   },
   "license": "SIL OPEN FONT LICENSE",


### PR DESCRIPTION
### What

* Drop `"require": "./dist/font.js",` this condition is wrong, geist doesn't have CJS bundle
* Set module type to "module"


### Why
It's already using ESM and `.js` extension, it should be treated as a ESM package.

Fix the dual exports (both CJS and ESM) since the CJS exports are not valid. rename `default` to `types` since those type files are for typing
