### PR TITLE
remove less than next 15 version restriction

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,6 +48,6 @@
   },
   "license": "SIL OPEN FONT LICENSE",
   "peerDependencies": {
-    "next": ">=13.2.0 <15.0.0-0"
+    "next": ">=13.2.0"
   }
 }


### PR DESCRIPTION
Since there's not much change for nextjs v15, so I think it's safe to say it's compatible