### PR TITLE
Bump Next.js Package to 1.3.1

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geist",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.",
   "main": "./dist/font.js",
   "type": "module",


### PR DESCRIPTION
- Adds docs for using in Pages router
- Fix typings for both CJS and ESM
- Remove Next.js version restriction to be less than version 15