### PR TITLE
Copyright info added to sources + fix in OFL

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2024 The Geist-Font.Git Project Authors (https://github.com/vercel/geist-font.git)
+Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font.git)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/sources/Geist.glyphspackage/fontinfo.plist
+++ b/sources/Geist.glyphspackage/fontinfo.plist
@@ -1,5 +1,5 @@
 {
-.appVersion = "3316";
+.appVersion = "3321";
 .formatVersion = 3;
 axes = (
 {
@@ -2274,6 +2274,15 @@ type = "italic angle";
 }
 );
 properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font.git)";
+}
+);
+},
 {
 key = designers;
 values = (

--- a/sources/GeistMono.glyphspackage/fontinfo.plist
+++ b/sources/GeistMono.glyphspackage/fontinfo.plist
@@ -1,5 +1,5 @@
 {
-.appVersion = "3316";
+.appVersion = "3321";
 .formatVersion = 3;
 axes = (
 {
@@ -2353,6 +2353,15 @@ type = "italic angle";
 }
 );
 properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copyright 2024 The Geist Project Authors (https://github.com/vercel/geist-font.git)";
+}
+);
+},
 {
 key = designers;
 values = (


### PR DESCRIPTION
@guidoferreyra This PR adds the name ID 0 (copyright) required in the fonts, and makes a minor fix in the OFL accordingly.

Please merge it and make a new release.


