### PR TITLE
[build] Troubleshoot the release job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Copy DESCRIPTION.en_us.html to artefact directory
         run: cp documentation/DESCRIPTION.en_us.html ${{ env.ZIP_NAME }}/DESCRIPTION.en_us.html
       - name: Copy ARTICLE.en_us.html to artefact directory
-        run: cp documentation/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/ARTICLE.en_us.html
+        run: cp documentation/article/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/article/ARTICLE.en_us.html
         continue-on-error: true
       - name: Copy OFL.txt to artefact directory
         run: cp OFL.txt ${{ env.ZIP_NAME }}/OFL.txt


### PR DESCRIPTION
This PR is to resolve workflow errors like this: https://github.com/vercel/geist-font/actions/runs/14519194609/job/40736301930

They appear to have been happening since this commit in September: https://github.com/vercel/geist-font/commit/30f2926382ea6ba57955f2829d719940fef5f292#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R94

The Github Actions history doesn't go back that far, so I can't fully confirm.

This PR points to `ARTICLE.en_us.html` in the `documentation/article/` directory instead of just `documentation/`.