### PR TITLE
[build] Fix the target location for ARTICLE.en_us.html

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Copy DESCRIPTION.en_us.html to artefact directory
         run: cp documentation/DESCRIPTION.en_us.html ${{ env.ZIP_NAME }}/DESCRIPTION.en_us.html
       - name: Copy ARTICLE.en_us.html to artefact directory
-        run: cp documentation/article/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/article/ARTICLE.en_us.html
+        run: cp documentation/article/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/ARTICLE.en_us.html
         continue-on-error: true
       - name: Copy OFL.txt to artefact directory
         run: cp OFL.txt ${{ env.ZIP_NAME }}/OFL.txt


### PR DESCRIPTION
This PR adjust the `cp` command in the release workflow from:

```
cp documentation/article/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/article/ARTICLE.en_us.html
```

To:

```
cp documentation/article/ARTICLE.en_us.html ${{ env.ZIP_NAME }}/ARTICLE.en_us.html
```