### PR TITLE
[release] v1.4.2 - packaging fix

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geist",
-  "version": "1.3.1",
+  "version": "1.4.2",
   "description": "Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.",
   "main": "./dist/font.js",
   "type": "module",


### PR DESCRIPTION
v1.4.01 was published to npm as v1.4.1 because of an npm auto-correction:

![image](https://github.com/user-attachments/assets/75897ad1-5eb2-4cd7-b5c9-18f1766084c6)

This PR establishes a v1.4.2 that makes no changes - it just aligns the version number in `package.json` with the one published on npm.