### PR TITLE
[ci]: install working corepack version

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -77,6 +77,13 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Hardcoded because we know it works, it would be fine to try to upgrade
+      - name: 'Install corepack@0.31'
+        shell: bash
+        run: |
+          npm install -g corepack@0.31
+          echo "corepack version after: $(corepack --version)"
+
       - name: Enable Corepack
         run: corepack enable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -172,6 +172,13 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Hardcoded because we know it works, it would be fine to try to upgrade
+      - name: 'Install corepack@0.31'
+        shell: bash
+        run: |
+          npm install -g corepack@0.31
+          echo "corepack version after: $(corepack --version)"
+
       - name: Enable Corepack
         run: corepack enable
 


### PR DESCRIPTION
## Context

We're failing to install corepack: https://github.com/vercel/geist-font/actions/runs/21690068616/job/62548508208.

## Solution

Install a working version of corepack.
