### PR TITLE
[ci]: fix build + release pipeline

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -34,12 +34,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
           sudo snap install yq
-      - uses: actions/cache@v4
-        with:
-          path: ./venv/
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
       - name: Set artifact file name
         id: zip-name
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
           sudo snap install yq
-      - uses: actions/cache@v4
-        with:
-          path: ./venv/
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
       - name: Set artifact file name
         id: zip-name
         shell: bash
@@ -198,7 +192,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.4.10
         with:
           publish: pnpm run release
           version: pnpm run version

--- a/.github/workflows/production-release.yaml
+++ b/.github/workflows/production-release.yaml
@@ -35,12 +35,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
           sudo snap install yq
-      - uses: actions/cache@v4
-        with:
-          path: ./venv/
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
       - name: Set artifact file name
         id: zip-name
         shell: bash


### PR DESCRIPTION
## Context

When doing releases, we experienced 2 issues:

1. Flakiness in the build, where triggering a new workflow appeared to resolve the issue: https://github.com/vercel/geist-font/actions/runs/21756393942/job/62767735684
2. `changesets/action` was not respecting `cwd`: https://github.com/vercel/geist-font/actions/runs/21759363287/job/62781569308

## Solution

1. Remove the cache. This should hopefully prevent the flakiness and I'm not really sure that we save much time anyways.
2. Pin the version of `changesets/action` to a previous version where `cwd` was working (see https://github.com/changesets/action/issues/501)
