### PR TITLE
fix(mono): publish geist@1.7.1 with liga regression revert

### DIFF
--- a/packages/next/.changeset/fix-geist-mono-liga.md
+++ b/packages/next/.changeset/fix-geist-mono-liga.md
@@ -1,0 +1,9 @@
+---
+"geist": patch
+---
+
+Fix Geist Mono rendering source-code text with unintended programming ligatures.
+
+v1.7.0 unintentionally activated programming-ligature substitutions (`-->`, `==`, `!=`, `...`, `--`, etc.) under the `liga` (Standard Ligatures) OpenType feature, which is on by default in every renderer. As a result, text like `--debug-prerender`, `[id...]`, `[...id]`, or `NODE_OPTIONS='--debug-prerender' node` rendered with ligated glyphs and broke monospace alignment in code.
+
+The source-level fix is in #217; this release ships the rebuilt binaries.


### PR DESCRIPTION
Adds a changeset so the production release workflow can publish `geist@1.7.1`. Source-level revert already landed in #217; CI (`make build`) will pick it up and produce fresh binaries.

## Background

v1.7.0 unintentionally activated programming-ligature substitutions (`-->`, `==`, `!=`, `...`, `--`, etc.) under the `liga` (Standard Ligatures) OpenType feature, which is on by default in every renderer. Source-code text like `--debug-prerender`, `[id...]`, `[...id]`, or `NODE_OPTIONS='--debug-prerender' node` rendered with ligated glyphs and broke monospace alignment.

Affects:
- `next/font/google` (Google Fonts serves the buggy v1.700 binary — separate PR: google/fonts#10540)
- `npm i geist@1.7.0` (bundled `packages/next/dist/fonts/geist-mono/*` has the same buggy GSUB)
- Any direct .ttf / .woff2 download

## Verification before publish

After release, the published `geist@1.7.1` binaries should have no `liga` feature in their GSUB table. Quick check:

```py
from fontTools.ttLib import TTFont
f = TTFont("node_modules/geist/dist/fonts/geist-mono/GeistMono-Regular.ttf")
assert "liga" not in {r.FeatureTag for r in f["GSUB"].table.FeatureList.FeatureRecord}
```