### PR TITLE
fix(release): sync package.json to 1.7.1 and stop ignoring packages/**/package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ proof
 node_modules
 package-lock.json
 package.json
+!packages/**/package.json
 master_ufo
 instance_ufos
 .ninja_log

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geist",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.",
   "main": "./dist/font.js",
   "type": "module",


### PR DESCRIPTION
## TL;DR

Sync `packages/next/package.json` to the version actually on npm (`1.7.1`) and stop the root `.gitignore` from silently dropping it from changesets release commits.

## Context

The last release published `geist@1.7.1` to npm and merged a `## 1.7.1` `CHANGELOG.md` entry on `main`, but `packages/next/package.json` is still at `1.7.0`. The `changesets/action` "Version Packages" PR was missing the version bump.

Root cause: the root `.gitignore` has had a broad `package.json` rule since the first commit (font-build noise). `changesets/action` with `commitMode: github-api` uses `@changesets/ghcommit`, which calls isomorphic-git's `git.isIgnored()` on every file. Unlike `git status`, `isIgnored()` returns `true` even for tracked files when a matching rule exists, so `packages/next/package.json` got silently dropped from the API commit even though `changeset version` bumped it on disk.

## Solution

- `packages/next/package.json`: bump `1.7.0` → `1.7.1` to match what's on npm.
- `.gitignore`: add `!packages/**/package.json` to exempt published packages from the broad ignore.

The next changesets release PR will now include the `package.json` bump.

Made with [Cursor](https://cursor.com)