### PR TITLE
fix(release): upload font zip to v$VERSION release tag, not geist@$VERSION

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,4 +218,4 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' packages/next/package.json)
           mv artifacts/geist-font.zip "geist-font-v$VERSION.zip"
-          gh release upload "geist@$VERSION" "geist-font-v$VERSION.zip" --clobber
+          gh release upload "v$VERSION" "geist-font-v$VERSION.zip" --clobber


### PR DESCRIPTION
## TL;DR

The `release-npm` job's last step targets `geist@$VERSION` but the release that `changesets/action` actually creates is named `v$VERSION`. The upload fails with `release not found` and the GitHub release ships without its font-zip asset, as happened for v1.7.1.

One-line fix.

## Root cause

In the CI run for the v1.7.1 release ([26189437225](https://github.com/vercel/geist-font/actions/runs/26189437225)), `release-npm` got as far as creating the release tag, then exited 1 on the upload:

```
🦋  success packages published successfully:
🦋  geist@1.7.1
🦋  Creating git tag...
🦋  New tag:  v1.7.1
...
Run gh release upload "geist@$VERSION" "geist-font-v$VERSION.zip" --clobber
release not found
##[error]Process completed with exit code 1.
```

Since the harden-release work in #222, `changesets/action@v1.8.0` with the current single-package layout creates the release at tag `v$VERSION`. The step right above this one already names the zip `geist-font-v$VERSION.zip` with the same prefix, so the two are now aligned. The legacy `geist@<version>` tag scheme is only present on releases from before #222 (e.g. [geist@1.7.0](https://github.com/vercel/geist-font/releases/tag/geist@1.7.0)).

## Downstream impact

v1.7.1 was the liga-regression fix from #221, so the missing zip leaves downstream consumers without the rebuild they need. Among them: the shadcn-ui docs site at https://ui.shadcn.com/docs/forms/react-hook-form#using-usefieldarray is currently shaping JSX spread `{...controllerField}` as `.{.controllerField}` because the served Geist Mono still has the `liga` substitution from v1.7.0 (tracked at shadcn-ui/ui#10796, CSS workaround at shadcn-ui/ui#10809).

The fix unblocks the next release; the missing v1.7.1 asset can be uploaded separately if desired.

## Verification

Exercised on the next merged "Version Packages" PR. Nothing else in CI calls this code path, so there's nothing local to run.

Closes #231.
Refs #225 (the release-tag-ordering question is a separate maintainer call; this PR only addresses the missing asset).