### PR TITLE
ci: remove temporary npm/OIDC publish diagnostics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,20 +196,6 @@ jobs:
           rm -rf packages/next/dist/fonts
           mv artifacts/packages/next/dist/fonts packages/next/dist/fonts
 
-      # TEMP diagnostic: ENEEDAUTH on OIDC publish (geist@1.7.2). Confirms whether
-      # the npm that `changeset publish` will use is the OIDC-capable one (>= 11.5.1)
-      # and whether the OIDC token endpoint is actually exposed to this job.
-      # Remove once the publish is fixed.
-      - name: Diagnose npm/OIDC publish environment
-        working-directory: packages/next
-        run: |
-          echo "node: $(node --version) ($(command -v node))"
-          echo "npm:  $(npm --version) ($(command -v npm))"
-          echo "pnpm: $(pnpm --version) ($(command -v pnpm))"
-          echo "registry: $(npm config get registry)"
-          echo "OIDC token URL present:   ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          echo "OIDC request token present: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1.8.0


### PR DESCRIPTION
Removes the temporary diagnostic step added in #234.

It did its job — confirmed the CI side is correct (npm 11.14.1 / OIDC-capable, both `ACTIONS_ID_TOKEN_REQUEST_*` env vars present, registry `registry.npmjs.org`), yet `geist@1.7.2` still fails `ENEEDAUTH`. So the cause is **registry-side** — the `geist` Trusted Publisher config on npmjs.org (tracked via #help-it), not the workflow.

Safe to merge anytime; ideally after the npm-side fix is confirmed so we keep the diagnostic available if we need another run.