### PR TITLE
fix(mono): bump font binary version 1.700 → 1.703

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,16 @@ This creates a markdown file in `packages/next/.changeset/` describing your chan
 - **minor**: New font weights, new features, backward-compatible additions
 - **major**: Breaking changes to the npm package's API or major font structure changes
 
+### Version Numbers
+
+Three version numbers live in this repo and they are related but not identical:
+
+1. **Package version**: `version` in `packages/next/package.json`, managed by Changesets and published as the npm `geist` semver (e.g. `1.7.3`).
+2. **Font binary version**: `head.fontRevision` baked into each `.otf`/`.ttf` from the FontMake build sources; what an OS or design tool reports for an installed font (e.g. `Version 1.703`).
+3. **GitHub release tag**: `v$VERSION` since [#233](https://github.com/vercel/geist-font/pull/233), matching the package version (e.g. `v1.7.3`).
+
+The binary version follows package version `1.X.Y` → binary `1.X0Y` (assuming single-digit `X` and `Y`): `1.7.0` ↔ `1.700`, `1.7.3` ↔ `1.703`, `1.8.0` ↔ `1.800`. The binary version only needs to advance when the font binary itself is being rebuilt for a release; the npm package can release a patch (e.g. for a non-font fix) without re-bumping the binary. When a release ships a font rebuild, bump the binary version in the same PR so the value reported by the font matches the package version it ships under.
+
 ### How Releases Work
 
 1. **On every push**: The CI builds fonts and runs tests

--- a/packages/next/.changeset/bump-geist-mono-font-version.md
+++ b/packages/next/.changeset/bump-geist-mono-font-version.md
@@ -1,0 +1,9 @@
+---
+"geist": patch
+---
+
+Bump Geist Mono font binary version 1.700 → 1.701.
+
+The internal font version stayed at 1.700 across the v1.7.1 and v1.7.2 npm releases even though `liga` was reverted at source in #217. Downstream consumers that key off the binary version (caches, font-validation pipelines, the `head.fontRevision` and `name` NameID-5 fields exposed in `fc-query`/DevTools) still see 1.700 and therefore can't tell apart a pre- and post-revert binary.
+
+Closes the second half of #231.

--- a/packages/next/.changeset/bump-geist-mono-font-version.md
+++ b/packages/next/.changeset/bump-geist-mono-font-version.md
@@ -2,8 +2,10 @@
 "geist": patch
 ---
 
-Bump Geist Mono font binary version 1.700 → 1.701.
+Bump Geist Mono font binary version 1.700 → 1.703.
 
 The internal font version stayed at 1.700 across the v1.7.1 and v1.7.2 npm releases even though `liga` was reverted at source in #217. Downstream consumers that key off the binary version (caches, font-validation pipelines, the `head.fontRevision` and `name` NameID-5 fields exposed in `fc-query`/DevTools) still see 1.700 and therefore can't tell apart a pre- and post-revert binary.
+
+The new value (`1.703`) matches the established `1.X.Y` → `1.<Y>0<Z>` convention already used by `Geist` (1.800 ↔ v1.8.0) and the prior `GeistMono` (1.700 ↔ v1.7.0): it lines up with the `v1.7.3` release this changeset will produce.
 
 Closes the second half of #231.

--- a/sources/GeistMono-Italic.glyphspackage/fontinfo.plist
+++ b/sources/GeistMono-Italic.glyphspackage/fontinfo.plist
@@ -4658,5 +4658,5 @@ O,
 };
 };
 versionMajor = 1;
-versionMinor = 700;
+versionMinor = 701;
 }

--- a/sources/GeistMono-Italic.glyphspackage/fontinfo.plist
+++ b/sources/GeistMono-Italic.glyphspackage/fontinfo.plist
@@ -4658,5 +4658,5 @@ O,
 };
 };
 versionMajor = 1;
-versionMinor = 701;
+versionMinor = 703;
 }

--- a/sources/GeistMono.glyphspackage/fontinfo.plist
+++ b/sources/GeistMono.glyphspackage/fontinfo.plist
@@ -4648,5 +4648,5 @@ O,
 };
 };
 versionMajor = 1;
-versionMinor = 701;
+versionMinor = 703;
 }

--- a/sources/GeistMono.glyphspackage/fontinfo.plist
+++ b/sources/GeistMono.glyphspackage/fontinfo.plist
@@ -4648,5 +4648,5 @@ O,
 };
 };
 versionMajor = 1;
-versionMinor = 700;
+versionMinor = 701;
 }


### PR DESCRIPTION
The internal font version stayed at 1.700 across the v1.7.1 and v1.7.2 npm releases even though the `liga` Standard Ligatures activation was reverted at source in #217. Downstream consumers that key off the binary version (caches, font-validation pipelines, the `head.fontRevision` and `name` NameID-5 fields exposed in `fc-query`/DevTools) still see 1.700 and can't distinguish a pre- and post-revert binary.

This bumps GeistMono and GeistMono-Italic to `versionMinor = 701` and ships a `patch` changeset so the release pipeline can roll a v1.7.3 with the rebuilt binaries.

Closes the second half of #231 (the version-not-incremented half flagged by @danarnold). The asset-zip half was closed by #233.